### PR TITLE
Add support for Scanner interface in rows.Scan

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -95,7 +95,7 @@ func (rs *rowSets) Scan(dest ...interface{}) error {
 					destVal.Elem().Kind(), val.Kind(), string(r.defs[i].Name))
 			}
 			if err := scanner.Scan(val.Interface()); err != nil {
-				return fmt.Errorf("Scanning value error for column '%s': %w", r.defs[i].Name, err)
+				return fmt.Errorf("Scanning value error for column '%s': %w", string(r.defs[i].Name), err)
 			}
 
 		}


### PR DESCRIPTION
It is currently not possible to create a `pgxmock.Rows` using standard flat values (not `struct`), and scan it to nullable values like `sql.Null*` or `pgxtype.*`. Of course it is possible to set such nullable values directly in the `pgxmock.Rows` but it is less natural. This PR modifies the Scan method, so that, if the source and destination type are not the same, we check if the destination type implements the Scanner interface and use it afterwards. The PR includes unit tests to check OK and KO cases. 

Also, `ExampleRows_customDriverValue()` now works, but we avoided to uncomment it, as you might have other reasons not to use it.