### PR TITLE
prevent double call rollback

### DIFF
--- a/pgxmock.go
+++ b/pgxmock.go
@@ -458,7 +458,6 @@ func (c *pgxmock) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f fu
 
 	fErr := f(tx)
 	if fErr != nil {
-		_ = tx.Rollback(ctx) // ignore rollback error as there is already an error to return
 		return fErr
 	}
 


### PR DESCRIPTION
its seems after `return fErr` function's return arg `err` receive value from fErr and defer always make Rollback.

Drop Rollback before statement