### PR TITLE
[+] add `PgConn()` method

### DIFF
--- a/pgxmock.go
+++ b/pgxmock.go
@@ -109,6 +109,8 @@ type pgxMockIface interface {
 	NewColumn(name string) *pgproto3.FieldDescription
 
 	ConnInfo() *pgtype.ConnInfo
+
+	PgConn() *pgconn.PgConn
 }
 
 type pgxIface interface {
@@ -124,6 +126,7 @@ type pgxIface interface {
 	Prepare(context.Context, string, string) (*pgconn.StatementDescription, error)
 	Deallocate(ctx context.Context, name string) error
 	ConnInfo() *pgtype.ConnInfo
+	PgConn() *pgconn.PgConn
 }
 
 type PgxConnIface interface {
@@ -261,6 +264,11 @@ func (c *pgxmock) NewRows(columns []string) *Rows {
 func (c *pgxmock) ConnInfo() *pgtype.ConnInfo {
 	ci := pgtype.ConnInfo{}
 	return &ci
+}
+
+func (c *pgxmock) PgConn() *pgconn.PgConn {
+	p := pgconn.PgConn{}
+	return &p
 }
 
 // NewRowsWithColumnDefinition allows Rows to be created from a

--- a/pgxmock.go
+++ b/pgxmock.go
@@ -266,6 +266,8 @@ func (c *pgxmock) ConnInfo() *pgtype.ConnInfo {
 	return &ci
 }
 
+// PgConn exposes the underlying low level postgres connection
+// This is just here to support interfaces that use it. Here is just returns an empty PgConn
 func (c *pgxmock) PgConn() *pgconn.PgConn {
 	p := pgconn.PgConn{}
 	return &p

--- a/pgxmock_test.go
+++ b/pgxmock_test.go
@@ -1240,3 +1240,13 @@ func TestConnInfo(t *testing.T) {
 
 	_ = mock.ConnInfo()
 }
+
+func TestPgConn(t *testing.T) {
+	mock, err := NewConn()
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mock.Close(context.Background())
+
+	_ = mock.PgConn()
+}


### PR DESCRIPTION
Similar to https://github.com/pashagolub/pgxmock/pull/86 we utilize the PgConn method so we need implemented in order to work with our interfaces.

Again I'm just returning an empty struct here because we at least don't need to testing anything with that method. We may need to do something with it down the line.