### PR TITLE
[+] make arguments matching using `WithArgs` mandatory, fixes #114

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -376,9 +376,6 @@ func (e *ExpectedQuery) WillReturnRows(rows ...*Rows) *ExpectedQuery {
 }
 
 func (e *queryBasedExpectation) argsMatches(args []interface{}) error {
-	if nil == e.args {
-		return nil
-	}
 	if len(args) != len(e.args) {
 		return fmt.Errorf("expected %d, but got %d arguments", len(e.args), len(args))
 	}

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -95,3 +95,17 @@ func TestQueryRowScan(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestMissingWithArgs(t *testing.T) {
+	mock, _ := NewConn()
+	// No arguments expected
+	mock.ExpectExec("INSERT something")
+	// Receiving argument
+	_, err := mock.Exec(context.Background(), "INSERT something", "something")
+	if err == nil {
+		t.Error("arguments do not match error was expected")
+	}
+	if err := mock.ExpectationsWereMet(); err == nil {
+		t.Error("expectation was not matched error was expected")
+	}
+}

--- a/pgxmock_test.go
+++ b/pgxmock_test.go
@@ -959,7 +959,7 @@ func TestPrepareExec(t *testing.T) {
 	mock.ExpectBegin()
 	ep := mock.ExpectPrepare("foo", "INSERT INTO ORDERS\\(ID, STATUS\\) VALUES \\(\\?, \\?\\)")
 	for i := 0; i < 3; i++ {
-		ep.ExpectExec().WillReturnResult(NewResult("UPDATE", 1))
+		ep.ExpectExec().WithArgs(AnyArg(), AnyArg()).WillReturnResult(NewResult("UPDATE", 1))
 	}
 	mock.ExpectCommit()
 	tx, _ := mock.Begin(context.Background())
@@ -1071,7 +1071,7 @@ func TestPreparedStatementCloseExpectation(t *testing.T) {
 	defer mock.Close(context.Background())
 
 	ep := mock.ExpectPrepare("foo", "INSERT INTO ORDERS").WillBeClosed()
-	ep.ExpectExec().WillReturnResult(NewResult("UPDATE", 1))
+	ep.ExpectExec().WithArgs(AnyArg(), AnyArg()).WillReturnResult(NewResult("UPDATE", 1))
 
 	_, err = mock.Prepare(context.Background(), "foo", "INSERT INTO ORDERS(ID, STATUS) VALUES (?, ?)")
 	if err != nil {
@@ -1101,7 +1101,7 @@ func TestExecExpectationErrorDelay(t *testing.T) {
 
 	// test that return of error is delayed
 	delay := time.Millisecond * 100
-	mock.ExpectExec("^INSERT INTO articles").
+	mock.ExpectExec("^INSERT INTO articles").WithArgs(AnyArg()).
 		WillReturnError(errors.New("slow fail")).
 		WillDelayFor(delay)
 


### PR DESCRIPTION
Proposed changes to make arguments matching mandatory.