### PR TITLE
[*] docs: update comment to include option to match out of order

### DIFF
--- a/pgxmock.go
+++ b/pgxmock.go
@@ -33,7 +33,8 @@ type pgxMockIface interface {
 	ExpectClose() *ExpectedClose
 
 	// ExpectationsWereMet checks whether all queued expectations
-	// were met in order. If any of them was not met - an error is returned.
+	// were met in order (unless MatchExpectationsInOrder set to false). 
+	// If any of them was not met - an error is returned.
 	ExpectationsWereMet() error
 
 	// ExpectPrepare expects Prepare() to be called with expectedSQL query.


### PR DESCRIPTION
This PR is more than a question than anything.  

Is it the case that `MatchExpectationsInOrder` is set to false `ExpectationsWereMet` will allow matching in any order.  Hence the documentation is slightly confusing as it is not clear that `ExpectationsWereMet` should be used if we are using goroutines.

Does this addition represent the behaviour more closely? 

