### PR TITLE
[-] fix bytes conversion panic when `RawValues` is called, fixes #128

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -127,7 +127,12 @@ func (rs *rowSets) RawValues() [][]byte {
 			dest[i] = b
 			continue
 		}
-		dest[i] = col.([]byte)
+		d, ok := col.([]byte)
+		if ok {
+			dest[i] = d
+		} else {
+			dest[i] = []byte(fmt.Sprintf("%v", col))
+		}
 	}
 
 	return dest


### PR DESCRIPTION

See: https://github.com/pashagolub/pgxmock/issues/128