### PR TITLE
improve `RawValues()` implementation

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -2,6 +2,7 @@ package pgxmock
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -99,7 +100,7 @@ func (rs *rowSets) Scan(dest ...interface{}) error {
 			if destElem := destVal.Elem(); destElem.CanSet() {
 				destElem.Set(val)
 			} else {
-				return fmt.Errorf("Cannot set destination value for column %s", string(r.defs[i].Name))
+				return fmt.Errorf("Cannot set destination value for column %s", r.defs[i].Name)
 			}
 		} else {
 			// Try to use Scanner interface
@@ -127,12 +128,7 @@ func (rs *rowSets) RawValues() [][]byte {
 			dest[i] = b
 			continue
 		}
-		d, ok := col.([]byte)
-		if ok {
-			dest[i] = d
-		} else {
-			dest[i] = []byte(fmt.Sprintf("%v", col))
-		}
+		dest[i] = []byte(fmt.Sprintf("%v", col))
 	}
 
 	return dest
@@ -170,8 +166,8 @@ func (rs *rowSets) empty() bool {
 }
 
 func rawBytes(col interface{}) (_ []byte, ok bool) {
-	val, ok := col.([]byte)
-	if !ok || len(val) == 0 {
+	val, err := json.Marshal(col)
+	if err != nil || len(val) == 0 {
 		return nil, false
 	}
 	// Copy the bytes from the mocked row into a shared raw buffer, which we'll replace the content of later

--- a/rows_test.go
+++ b/rows_test.go
@@ -877,7 +877,7 @@ func TestMockQueryWithCollect(t *testing.T) {
 	//	t.Error("it must have had one row as result, but got empty result set instead")
 	//}
 
-	rawMap, err := pgx.CollectRows(rows, pgx.RowToStructByPos[rowStructType])
+	rawMap, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByPos[rowStructType])
 	if err != nil {
 		t.Errorf("error '%s' was not expected while trying to collect rows", err)
 	}

--- a/rows_test.go
+++ b/rows_test.go
@@ -2,6 +2,7 @@ package pgxmock
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -424,7 +425,11 @@ func ExampleRows_rawValues() {
 	defer rs.Close()
 
 	for rs.Next() {
-		fmt.Println(string(rs.RawValues()[0]))
+		var rawValue []byte
+		if err := json.Unmarshal(rs.RawValues()[0], &rawValue); err != nil {
+			fmt.Print(err)
+		}
+		fmt.Println(string(rawValue))
 	}
 	// Output: one binary value with some text!
 	// two binary value with even more text than the first one


### PR DESCRIPTION
As I raised issue #128, @Eitol had resolved it wisely by converting all of types into byte slice by making string value of that value.(#137) However, it could cause a potential vulnerability if pgx call RawValues() to decode column values. As of now, this implementation doesn't cause any vulnerability because pgx doesn't call RawValue to decode column values. But just in case, I wanted to prevent this vulnerability.

The implementation is simple. I applied json Marshal to encode values. We can decode all of primitive types in golang, even time.Time type can be encoded. Therefore, we don't have to concern about if there would be a type can't be converted in pgx. Pgx support all of primitive types, slices of them, and time.Time type. 

I considered about just decoding into binary by using encoding/binary package, but types like time.Time is an obstacle. I don't want to consider types in pgxmock's RawValue method. Json Marshalling was the simplest way to acheive my goal.

p.s I fixed test code to use pgx.RowToAddrOfStructByPos because the method which caused panic was pgx.RowToAddrOfStructByPos, not pgx.RowToStructByPos