### PR TITLE
[+] add missing methods to mock `pgxpool.Pool`

### DIFF
--- a/pgxmock.go
+++ b/pgxmock.go
@@ -153,7 +153,7 @@ func (c *pgxmock) Config() *pgxpool.Config {
 	return &pgxpool.Config{}
 }
 
-func (c *pgxmock) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
+func (c *pgxmock) AcquireAllIdle(_ context.Context) []*pgxpool.Conn {
 	return []*pgxpool.Conn{}
 }
 

--- a/pgxmock.go
+++ b/pgxmock.go
@@ -107,7 +107,7 @@ type pgxMockIface interface {
 	// New Column allows to create a Column
 	NewColumn(name string) *pgconn.FieldDescription
 
-	Config() *pgx.ConnConfig
+	Config() *pgxpool.Config
 
 	PgConn() *pgconn.PgConn
 }
@@ -119,6 +119,7 @@ type pgxIface interface {
 	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
 	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
 	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Reset()
 	Ping(context.Context) error
 	Prepare(context.Context, string, string) (*pgconn.StatementDescription, error)
 	Deallocate(ctx context.Context, name string) error
@@ -134,6 +135,8 @@ type PgxPoolIface interface {
 	pgxIface
 	pgx.Tx
 	Acquire(ctx context.Context) (*pgxpool.Conn, error)
+	AcquireAllIdle(ctx context.Context) []*pgxpool.Conn
+	AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error
 	Close()
 	Stat() *pgxpool.Stat
 }
@@ -146,9 +149,19 @@ type pgxmock struct {
 	expected []expectation
 }
 
-func (c *pgxmock) Config() *pgx.ConnConfig {
-	return &pgx.ConnConfig{}
+func (c *pgxmock) Config() *pgxpool.Config {
+	return &pgxpool.Config{}
 }
+
+func (c *pgxmock) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
+	return []*pgxpool.Conn{}
+}
+
+func (c *pgxmock) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
+	return nil
+}
+
+func (c *pgxmock) Reset()
 
 // region Expectations
 func (c *pgxmock) ExpectClose() *ExpectedClose {

--- a/pgxmock.go
+++ b/pgxmock.go
@@ -157,7 +157,7 @@ func (c *pgxmock) AcquireAllIdle(_ context.Context) []*pgxpool.Conn {
 	return []*pgxpool.Conn{}
 }
 
-func (c *pgxmock) AcquireFunc(_ context.Context, f func(*pgxpool.Conn) error) error {
+func (c *pgxmock) AcquireFunc(_ context.Context, _ func(*pgxpool.Conn) error) error {
 	return nil
 }
 

--- a/pgxmock.go
+++ b/pgxmock.go
@@ -161,7 +161,9 @@ func (c *pgxmock) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) 
 	return nil
 }
 
-func (c *pgxmock) Reset()
+func (c *pgxmock) Reset() {
+
+}
 
 // region Expectations
 func (c *pgxmock) ExpectClose() *ExpectedClose {

--- a/pgxmock.go
+++ b/pgxmock.go
@@ -157,7 +157,7 @@ func (c *pgxmock) AcquireAllIdle(_ context.Context) []*pgxpool.Conn {
 	return []*pgxpool.Conn{}
 }
 
-func (c *pgxmock) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
+func (c *pgxmock) AcquireFunc(_ context.Context, f func(*pgxpool.Conn) error) error {
 	return nil
 }
 


### PR DESCRIPTION
Add some of the missing methods to pgxpool from latest v5 updates and adjust Config() func.