### PR TITLE
[+] add `Kind()` method to convert `*Rows` to `pgx.Rows` interface

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -275,6 +275,14 @@ func (r *Rows) FromCSVString(s string) *Rows {
 	return r
 }
 
+// Kind returns rows corresponding to the interface pgx.Rows
+// useful for testing entities that implement an interface pgx.RowScanner
+func (r *Rows) Kind() pgx.Rows {
+	return &rowSets{
+		sets: []*Rows{r},
+	}
+}
+
 // NewRowsWithColumnDefinition return rows with columns metadata
 func NewRowsWithColumnDefinition(columns ...pgconn.FieldDescription) *Rows {
 	return &Rows{

--- a/rows_test.go
+++ b/rows_test.go
@@ -671,3 +671,32 @@ func TestMockQueryWithCollect(t *testing.T) {
 func TestRowsConn(t *testing.T) {
 	assert.Nil(t, (&rowSets{}).Conn())
 }
+
+func TestRowsKind(t *testing.T) {
+	var alphabet = []string{"a", "b", "c", "d", "e", "f"}
+	rows := NewRows([]string{"id", "alphabet"})
+
+	for id, b := range alphabet {
+		rows.AddRow(id, b)
+	}
+
+	kindRows := rows.Kind()
+
+	for i := 0; kindRows.Next(); i++ {
+		var (
+			letter string
+			index  int
+		)
+		if err := kindRows.Scan(&index, &letter); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if index != i {
+			t.Fatalf("expected %d, but got %d", i, index)
+		}
+
+		if letter != alphabet[i] {
+			t.Fatalf("expected %s, but got %s", alphabet[i], letter)
+		}
+	}
+}


### PR DESCRIPTION
Kind returns rows corresponding to the interface pgx.Rows
useful for testing entities that implement an interface pgx.RowScanner

example

```go
package notifier

import (
	"github.com/go-faker/faker/v4"
	"github.com/jackc/pgx/v5"
	"github.com/pashagolub/pgxmock/v3"
	"testing"
)

var fixtureBench = func() pgx.Rows {
	mock, _ := pgxmock.NewPool()

	rows := mock.NewRows([]string{"id", "email", "name", "phone"})
	for i := 0; i < 100_000; i++ {
		rows.AddRow(i, faker.Email(), faker.Name(), faker.Phonenumber())
	}

	return rows.Kind()
}()

func BenchmarkAudience_ScanRow(b *testing.B) {
	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		audience := &Audience{}
		err := audience.ScanRow(fixtureBench)
		if err != nil {
			b.Fatal(err)
		}
	}
}

```