### PR TITLE
fix: removing undefined max method in expectations

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -52,7 +52,10 @@ func (e *commonExpectation) fulfill() {
 }
 
 func (e *commonExpectation) fulfilled() bool {
-	return e.triggered >= max(e.plannedCalls, 1)
+	if e.plannedCalls <= 0 {
+		return e.triggered >= 1
+	}
+	return e.triggered >= e.plannedCalls
 }
 
 func (e *commonExpectation) required() bool {


### PR DESCRIPTION
Hi,
I'm trying pgxmock in these days and I noticed that the expectations file contained the following function:
```go
func (e *commonExpectation) fulfilled() bool {
	return e.triggered >= max(e.plannedCalls, 1)
}
```

Both using the library and downloading the source code, seems that the `max` function is missing. This results in something similar to this:

```
$ go test -v ./...
# github.com/pashagolub/pgxmock/v3
../../go/pkg/mod/github.com/pashagolub/pgxmock/v3@v3.2.0/expectations.go:55:24: undefined: max
note: module requires Go 1.21
FAIL    github.com/Kavuti/my-application-module [build failed]
FAIL
```

I reimplemented with a simple logic without using the `math.Max` function from the stdlib to avoid conversions to/from float64.
I tested the new behaviour in my personal project and after changing that part of code seems that everything works as expected.

Let me know if you need more information or modifications in order to fix this.
Thank you,
Christian