### PR TITLE
fix: scanning of a single row without rows.Next()

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -82,6 +82,9 @@ func (rs *rowSets) Scan(dest ...interface{}) error {
 	if len(r.rows) == 0 {
 		return pgx.ErrNoRows
 	}
+	if len(r.rows) == 1 && r.recNo == 0 {
+		r.recNo++
+	}
 	for i, col := range r.rows[r.recNo-1] {
 		if dest[i] == nil {
 			//behave compatible with pgx

--- a/rows_test.go
+++ b/rows_test.go
@@ -517,6 +517,32 @@ func TestRowsScanWithScannerIface(t *testing.T) {
 
 }
 
+func TestSingleRowScanWithScannerIface(t *testing.T) {
+	mock, err := NewConn()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mock.Close(context.Background())
+
+	r := NewRows([]string{"col1"}).AddRow(int64(23))
+	mock.ExpectQuery("SELECT").WillReturnRows(r)
+
+	rs, err := mock.Query(context.Background(), "SELECT")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var result testScanner
+	if rs.Scan(&result) != nil {
+		t.Fatal("unexpected error for scan")
+	}
+
+	if result.Value != int64(23) {
+		t.Fatalf("expected Value to be 23 but got: %d", result.Value)
+	}
+
+}
+
 func TestRowsScanErrorOnScannerIface(t *testing.T) {
 	mock, err := NewConn()
 	if err != nil {


### PR DESCRIPTION
Resolving https://github.com/pashagolub/pgxmock/issues/174