### PR TITLE
[-] fix for nil pointer exception when using `.Kind()` and closing the rows

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -80,7 +80,9 @@ func (rs *rowSets) FieldDescriptions() []pgconn.FieldDescription {
 // }
 
 func (rs *rowSets) Close() {
-	rs.ex.rowsWereClosed = true
+	if rs.ex != nil {
+		rs.ex.rowsWereClosed = true
+	}
 	// return rs.sets[rs.pos].closeErr
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -708,6 +708,10 @@ func TestRowsKind(t *testing.T) {
 			t.Fatalf("expected %s, but got %s", alphabet[i], letter)
 		}
 	}
+
+	// Test closing as this is called by the pgx library in pgx.CollectRows
+	// Previously this caused a nil pointer exception when Close was called on kindRows
+	kindRows.Close()
 }
 
 // TestConnRow tests the ConnRow interface implementation for Conn.QueryRow.


### PR DESCRIPTION
In our tests for PGX we are using the `pgxmock.Rows.Kind()` method to retrieve the `pgx.Rows` compatible type. When used in combination of `pgx.CollectRows` this causes a nil pointer exception.

Reason being that the `rowSets.Close` method is trying to access the `ExpectedQuery` object to set the property `rowsWereClosed`. But the `pgxmock.Rows.Kind()` never sets the `ex` property and therefore it is nil.

I thought about setting the `rowSets.ex` property to an empty `ExpectedQuery` object, but that feels wrong as the `pgx.Rows` type does not need the `ExpectedQuery` object. That is why I added this nil check in the close method.

### Changes
- Added nil check in `pgxmock.Rows.Close` method.
- Added test to call Close to prevent errors from happening in the future.

### How to test
The easiest way to test it in master is to call `kindRows.Close()` in the `TestRowsKind` in `rows_test.go`.

Integration test:
Create a new PGXMock row set with the `pgxmock.NewRows` and add some rows. Then on the `*pgxmock.Rows` call the `.Kind()` method and use the result in for example the `pgx.CollectRows` method. You will get a nil pointer exception with the current version.