### PR TITLE
Remove empty string check in commandTag

### DIFF
--- a/pgxmock.go
+++ b/pgxmock.go
@@ -521,9 +521,6 @@ func (c *pgxmock) Exec(ctx context.Context, query string, args ...interface{}) (
 				return err
 			}
 		}
-		if execExp.result.String() == "" && execExp.err == nil {
-			return fmt.Errorf("Exec must return a result or raise an error: %s", execExp)
-		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Hi!
I think it would be more convenient to remove the check for an empty string in commandTag because it's a valid case. Also, it will allow you not to think about the return value once again