### PR TITLE
Convert types in `Scan` if possible

### DIFF
--- a/pgxmock_test.go
+++ b/pgxmock_test.go
@@ -495,10 +495,12 @@ func TestRowBuilderAndNilTypes(t *testing.T) {
 	}
 	defer rows.Close()
 
+	type boolAlias bool
+
 	// NullTime and NullInt are used from stubs_test.go
 	var (
 		id      int
-		active  bool
+		active  boolAlias
 		created NullTime
 		status  NullInt
 	)

--- a/rows.go
+++ b/rows.go
@@ -1,6 +1,7 @@
 package pgxmock
 
 import (
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -133,18 +134,20 @@ func (rs *rowSets) Scan(dest ...interface{}) error {
 			} else {
 				return fmt.Errorf("Cannot set destination value for column %s", r.defs[i].Name)
 			}
-		} else {
+		} else if scanner, ok := destVal.Interface().(sql.Scanner); ok {
 			// Try to use Scanner interface
-			scanner, ok := destVal.Interface().(interface{ Scan(interface{}) error })
-
-			if !ok {
-				return fmt.Errorf("Destination kind '%v' not supported for value kind '%v' of column '%s'",
-					destVal.Elem().Kind(), val.Kind(), string(r.defs[i].Name))
-			}
 			if err := scanner.Scan(val.Interface()); err != nil {
 				return fmt.Errorf("Scanning value error for column '%s': %w", string(r.defs[i].Name), err)
 			}
-
+		} else if val.CanConvert(destVal.Elem().Type()) {
+			if destElem := destVal.Elem(); destElem.CanSet() {
+				destElem.Set(val.Convert(destElem.Type()))
+			} else {
+				return fmt.Errorf("Cannot set destination value for column %s", r.defs[i].Name)
+			}
+		} else {
+			return fmt.Errorf("Destination kind '%v' not supported for value kind '%v' of column '%s'",
+				destVal.Elem().Kind(), val.Kind(), string(r.defs[i].Name))
 		}
 	}
 	return r.nextErr[r.recNo-1]


### PR DESCRIPTION
`rowSets.Scan()` checks if value type assignable to destination element type or destination type implements `sql.Scanner` interface. It doesn't check if value type can be converted to destination element type.

Using primitive type alias will result in error:
```go
rs := NewRows([]string{"id", "active", "created", "status"}).        
        AddRow(1, true, NullTime{time.Now(), true}, NullInt{5, true}).        
        AddRow(2, false, NullTime{Valid: false}, NullInt{Valid: false})        
 
mock.ExpectQuery("SELECT (.+) FROM sales").WillReturnRows(rs)        
 
rows, err := mock.Query(context.Background(), "SELECT * FROM sales")        
if err != nil {        
        t.Fatalf("error '%s' was not expected while retrieving mock rows", err)        
}        
defer rows.Close()        
 
type boolAlias bool
 
// NullTime and NullInt are used from stubs_test.go        
var (        
        id      int        
        active  boolAlias        
        created NullTime        
        status  NullInt        
)        
 
if !rows.Next() {        
        t.Fatal("it must have had row in rows, but got empty result set instead")        
}        
 
err = rows.Scan(&id, &active, &created, &status)        
if err != nil {        
        t.Errorf("error '%s' was not expected while trying to scan row", err)        
}
```
```
pgxmock_test.go:514: error 'Destination kind 'bool' not supported for value kind 'bool' of column 'active'' was not expected while trying to scan row
pgxmock_test.go:522: expected 'active' to be 'true', but got 'false' instead
pgxmock_test.go:526: expected 'created' to be valid, but it {Time:0001-01-01 00:00:00 +0000 UTC Valid:false} is not
pgxmock_test.go:530: expected 'status' to be valid, but it {Integer:0 Valid:false} is not
pgxmock_test.go:534: expected 'status' to be '5', but got '0'
pgxmock_test.go:544: error 'Destination kind 'bool' not supported for value kind 'bool' of column 'active'' was not expected while trying to scan row
```
Of course, there won't be any problems if specify the type at `AddRow()` call, but it doesn't looks elegant:
```go
type boolAlias bool

rs := NewRows([]string{"id", "active", "created", "status"}).        
        AddRow(1, boolAlias(true), NullTime{time.Now(), true}, NullInt{5, true}).        
        AddRow(2, boolAlias(false), NullTime{Valid: false}, NullInt{Valid: false})        
```
So I offer to use type conversion if possible.

The type conversion is being used within [standard `database/sql` package](https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/database/sql/convert.go;l=422), so I think it's compliant to use it in `pgxmock` library too:
```go
	if dv.Kind() == sv.Kind() && sv.Type().ConvertibleTo(dv.Type()) {
		dv.Set(sv.Convert(dv.Type()))
		return nil
	}
```