### PR TITLE
[*] update `pgxmock` module version to v5 to match release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/pashagolub/pgxmock.svg)](https://pkg.go.dev/github.com/pashagolub/pgxmock/v4)
-[![Go Report Card](https://goreportcard.com/badge/github.com/pashagolub/pgxmock)](https://goreportcard.com/report/github.com/pashagolub/pgxmock/v4)
+[![Go Reference](https://pkg.go.dev/badge/github.com/pashagolub/pgxmock.svg)](https://pkg.go.dev/github.com/pashagolub/pgxmock/v5)
+[![Go Report Card](https://goreportcard.com/badge/github.com/pashagolub/pgxmock)](https://goreportcard.com/report/github.com/pashagolub/pgxmock/v5)
 [![Coverage Status](https://coveralls.io/repos/github/pashagolub/pgxmock/badge.svg?branch=master)](https://coveralls.io/github/pashagolub/pgxmock?branch=master)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
@@ -17,11 +17,11 @@ It's based on the well-known [sqlmock](https://github.com/DATA-DOG/go-sqlmock) l
 
 ## Install
 
-    go get github.com/pashagolub/pgxmock/v4
+    go get github.com/pashagolub/pgxmock/v5
 
 ## Documentation and Examples
 
-Visit [godoc](http://pkg.go.dev/github.com/pashagolub/pgxmock/v4) for general examples and public api reference.
+Visit [godoc](http://pkg.go.dev/github.com/pashagolub/pgxmock/v5) for general examples and public api reference.
 
 See implementation examples:
 
@@ -92,7 +92,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pashagolub/pgxmock/v4"
+	"github.com/pashagolub/pgxmock/v5"
 )
 
 // a successful case
@@ -175,7 +175,7 @@ provide a standard sql parsing matchers.
 ## Matching arguments like time.Time
 
 There may be arguments which are of `struct` type and cannot be compared easily by value like `time.Time`. In this case
-**pgxmock** provides an [Argument](https://pkg.go.dev/github.com/pashagolub/pgxmock/v4#Argument) interface which
+**pgxmock** provides an [Argument](https://pkg.go.dev/github.com/pashagolub/pgxmock/v5#Argument) interface which
 can be used in more sophisticated matching. Here is a simple example of time argument matching:
 
 ``` go

--- a/examples/basic/basic_test.go
+++ b/examples/basic/basic_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pashagolub/pgxmock/v4"
+	"github.com/pashagolub/pgxmock/v5"
 )
 
 // a successful case

--- a/examples/blog/blog_test.go
+++ b/examples/blog/blog_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/pashagolub/pgxmock/v4"
+	"github.com/pashagolub/pgxmock/v5"
 )
 
 func (a *api) assertJSON(actual []byte, data interface{}, t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pashagolub/pgxmock/v4
+module github.com/pashagolub/pgxmock/v5
 
 go 1.23.0
 


### PR DESCRIPTION
It looks like you tagged [v5.0.0](https://github.com/pashagolub/pgxmock/releases/tag/v5.0.0) without revising the module path to append the new major version in `go.mod` module name's version according to the [release workflow](https://go.dev/doc/modules/release-workflow#breaking).

After merging this PR, you can register the change by doing one of the following:
- Visiting the [pgxmock/v5 page](https://pkg.go.dev/github.com/pashagolub/pgxmock/v5) on pkg.go.dev, and clicking the “Request” button. 
- Downloading the package via the [go command](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them). For example:
 GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/pashagolub/pgxmock/v5@v5.0.0
- Making a request to proxy.golang.org for the module version, to any endpoint specified by the [Module proxy protocol](https://pkg.go.dev/cmd/go/#hdr-Module_proxy_protocol). For example:
https://proxy.golang.org/github.com/pashagolub/pgxmock/v5@v/v5.0.0.info 

