### PR TITLE
[-] return non-nil errRows from Query on failure, fixes #258

### DIFF
--- a/pgxmock.go
+++ b/pgxmock.go
@@ -488,16 +488,30 @@ func (c *pgxmock) Query(ctx context.Context, sql string, args ...interface{}) (p
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return &errRows{err: err}, err
 	}
 	return ex.rows, ex.waitForDelay(ctx)
 }
+
+type errRows struct {
+	err error
+}
+
+func (er *errRows) Close()                                    {}
+func (er *errRows) Err() error                                { return er.err }
+func (er *errRows) CommandTag() pgconn.CommandTag             { return pgconn.CommandTag{} }
+func (er *errRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (er *errRows) Next() bool                                { return false }
+func (er *errRows) Scan(...any) error          { return er.err }
+func (er *errRows) Values() ([]any, error)     { return nil, er.err }
+func (er *errRows) RawValues() [][]byte                       { return nil }
+func (er *errRows) Conn() *pgx.Conn                           { return nil }
 
 type errRow struct {
 	err error
 }
 
-func (er errRow) Scan(...interface{}) error {
+func (er errRow) Scan(...any) error {
 	return er.err
 }
 

--- a/pgxmock_test.go
+++ b/pgxmock_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	pgx "github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 )
@@ -1329,4 +1330,24 @@ func TestIssue258QueryReturnsErrRowsOnFailure(t *testing.T) {
 	if collectErr == nil {
 		t.Fatal("expected an error from CollectOneRow, got nil")
 	}
+}
+
+// TestIssue258ErrRowsAllMethods exercises every method on errRows to ensure
+// full coverage of the sentinel rows type returned on Query failure.
+func TestIssue258ErrRowsAllMethods(t *testing.T) {
+	a := assert.New(t)
+	origErr := errors.New("sentinel query error")
+	er := &errRows{err: origErr}
+
+	a.NotPanics(er.Close)
+	a.Equal(origErr, er.Err())
+	a.Equal(pgconn.CommandTag{}, er.CommandTag())
+	a.Nil(er.FieldDescriptions())
+	a.False(er.Next())
+	a.Equal(origErr, er.Scan())
+	vals, valErr := er.Values()
+	a.Nil(vals)
+	a.Equal(origErr, valErr)
+	a.Nil(er.RawValues())
+	a.Nil(er.Conn())
 }

--- a/pgxmock_test.go
+++ b/pgxmock_test.go
@@ -1303,3 +1303,30 @@ func TestDoubleUnlock(t *testing.T) {
 	a.Error(err)
 	a.NotPanics(func() { _ = mock.Ping(ctx) })
 }
+
+// TestIssue258QueryReturnsErrRowsOnFailure verifies that Query returns a non-nil
+// pgx.Rows even on failure, allowing callers to use pgx.CollectOneRow / pgx.CollectRows
+// without nil-checking the rows value first (mirrors pgx pool behaviour).
+func TestIssue258QueryReturnsErrRowsOnFailure(t *testing.T) {
+	mock, err := NewPool()
+	if err != nil {
+		t.Fatalf("unexpected error opening mock pool: %s", err)
+	}
+	defer mock.Close()
+
+	// No expectation registered – Query should fail with an error.
+	rows, queryErr := mock.Query(t.Context(), "SELECT 1")
+
+	if queryErr == nil {
+		t.Fatal("expected an error from Query, got nil")
+	}
+	if rows == nil {
+		t.Fatal("expected non-nil rows even on Query failure")
+	}
+
+	// pgx.CollectOneRow must not panic and must propagate the error.
+	_, collectErr := pgx.CollectOneRow(rows, pgx.RowTo[int])
+	if collectErr == nil {
+		t.Fatal("expected an error from CollectOneRow, got nil")
+	}
+}

--- a/rows.go
+++ b/rows.go
@@ -137,7 +137,7 @@ func (rs *rowSets) Scan(dest ...interface{}) error {
 			continue
 		}
 		destVal := reflect.ValueOf(dest[i])
-		if destVal.Kind() != reflect.Ptr {
+		if destVal.Kind() != reflect.Pointer {
 			return fmt.Errorf("destination argument must be a pointer for column %s", r.defs[i].Name)
 		}
 		if col == nil {

--- a/rows_test.go
+++ b/rows_test.go
@@ -795,10 +795,6 @@ func TestMockQueryWithCollect(t *testing.T) {
 	var id = rawMap[0].ID
 	var title = rawMap[0].Title
 
-	if err != nil {
-		t.Fatalf("error '%s' was not expected while trying to scan row", err)
-	}
-
 	if id != 5 {
 		t.Errorf("expected mocked id to be 5, but got %d instead", id)
 	}


### PR DESCRIPTION
pgx's `pool.Query` returns an `errRows` sentinel (not nil) when a query fails, so callers can safely pass the rows value to `pgx.CollectRows` & `pgx.CollectOneRow` without first nil-checking it.

pgxmock was returning nil rows on any `Query` error, causing a nil-pointer panic when code followed that pattern.

Add an `errRows` type that implements `pgx.Rows` and surfaces the error through every method. Query now returns `&errRows{err}` instead of nil when no matching expectation is found or an expectation returns an error.

Add `TestIssue258QueryReturnsErrRowsOnFailure` to reproduce the panic and confirm the fix.